### PR TITLE
bug fix for create route

### DIFF
--- a/routes/task.js
+++ b/routes/task.js
@@ -163,9 +163,7 @@ function checkErrorTaskData(res, data) {
         typeof data.long === 'undefined' ||
         typeof data.radius === 'undefined' ||
         typeof data.done === 'undefined' ||
-        typeof data.enter === 'undefined' ||
-        // typeof data.task_id === 'undefined'
-      ) {
+        typeof data.enter === 'undefined') {
     res.json({
       "error": "Invalid PUT or POST format. See below for correct format.",
       "message": {

--- a/routes/task.js
+++ b/routes/task.js
@@ -51,6 +51,7 @@ router.post('/:userID', function(req, res) {
     req.body.radius = JSON.parse(req.body.radius)
     req.body.done = JSON.parse(req.body.done)
     req.body.enter = JSON.parse(req.body.enter)
+
     api.tasks.getTaskCount(db, userID).then(function(results) {
       req.body.task_id = results[0].count + 1
       api.tasks.createTask(db, userID, req.body).then(function(results) {

--- a/routes/task.js
+++ b/routes/task.js
@@ -44,6 +44,7 @@ router.post('/:userID', function(req, res) {
   }
 
   if (checkErrorTaskData(res, req.body)) {
+    console.log(req.body)
     return
   }
 


### PR DESCRIPTION
the error handler was checking for a task.task_id value, but before it was being set so it was always falsey.
